### PR TITLE
Use sim time so that /tf time matches /image_raw time

### DIFF
--- a/fiducial_vlam/launch/sim_one_marker_launch.py
+++ b/fiducial_vlam/launch/sim_one_marker_launch.py
@@ -21,9 +21,9 @@ make_not_use_map = 0
 corner_measurement_sigma = 1.0
 
 vloc_args = [{
-    'use_sim_time': False,  # Don't use /clock
+    'use_sim_time': True,  # Use /clock
     'publish_tfs': 1,  # Publish drone and camera /tf
-    'stamp_msgs_with_current_time': 1,  # Stamp with now()
+    'stamp_msgs_with_current_time': 0,  # Stamp with now()
     'map_init_pose_z': 0,
     'sub_camera_info_best_effort_not_reliable': 1,
     'publish_tfs_per_marker': 0,
@@ -36,7 +36,7 @@ vloc_args = [{
 }]
 
 vmap_args = [{
-    'use_sim_time': False,  # Don't use /clock
+    'use_sim_time': True,  # Use /clock
     'publish_tfs': 1,  # Publish marker /tf
     'marker_length': 0.1778,  # Marker length
     'marker_map_save_full_filename': map_filename,


### PR DESCRIPTION
I figured out why I couldn't see images in rviz2: vlam was publishing /tf with wall time, but the Gazebo camera plugin was publishing /image_raw with sim time. The MessageFilter rejected all of the tf messages as being too far into the future. The fix is to get everybody to use sim time.

As we know, sim time can have repeated timestamps, but the gtsam tests we're running don't care if the timestamps repeat, so this works fine.

In my orca2 workspace I went the other way: I hacked up gazebo_ros_pkgs to publish wall time, and changed everything to use wall time. I suppose this is why I need to keep 2 separate workspaces.