### PR TITLE
Fixes to compose nodes

### DIFF
--- a/fiducial_vlam/CMakeLists.txt
+++ b/fiducial_vlam/CMakeLists.txt
@@ -126,6 +126,11 @@ ament_target_dependencies(vloc_main
   ${VLOC_NODE_DEPS})
 
 # ?? Why can't I put this in ament_target_dependencies
+target_link_libraries(vloc_node
+  gtsam
+  )
+
+# ?? Why can't I put this in ament_target_dependencies
 target_link_libraries(vloc_main
   gtsam
   )
@@ -186,7 +191,16 @@ target_link_libraries(vmap_main
 # Install
 #=============
 
-# Install targets
+# Install composable nodes
+install(TARGETS
+  vloc_node
+  vmap_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  )
+
+# Install executables
 install(TARGETS
   vloc_main
   vmap_main

--- a/fiducial_vlam/CMakeLists.txt
+++ b/fiducial_vlam/CMakeLists.txt
@@ -97,6 +97,7 @@ set(VLOC_NODE_DEPS
   class_loader
   cv_bridge
   fiducial_vlam_msgs
+  GTSAM
   nav_msgs
   OpenCV
   rclcpp
@@ -194,7 +195,15 @@ target_link_libraries(vmap_main
 # Install composable nodes
 install(TARGETS
   vloc_node
+  EXPORT export_vloc_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  )
+
+install(TARGETS
   vmap_node
+  EXPORT export_vmap_node
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -214,10 +223,20 @@ install(DIRECTORY
   DESTINATION share/fiducial_vlam
   )
 
-ament_export_include_directories(include)
-
 install(DIRECTORY include/
   DESTINATION include)
+
+#=============
+# Export
+#=============
+
+ament_export_dependencies(class_loader yaml_cpp_vendor)
+
+ament_export_include_directories(include)
+
+ament_export_interfaces(export_vloc_node export_vmap_node)
+
+ament_export_libraries(vloc_node vmap_node)
 
 #=============
 # Run ament macros

--- a/fiducial_vlam/src/vloc_node.cpp
+++ b/fiducial_vlam/src/vloc_node.cpp
@@ -144,6 +144,12 @@ namespace fiducial_vlam
         rclcpp::ServicesQoS(),
         [this](sensor_msgs::msg::Image::UniquePtr msg) -> void
         {
+#undef SHOW_ADDRESS
+#ifdef SHOW_ADDRESS
+          static int count = 0;
+          RCLCPP_INFO(get_logger(), "%d, %p", count++, reinterpret_cast<std::uintptr_t>(msg.get()));
+#endif
+
           // the stamp to use for all published messages derived from this image message.
           auto stamp{msg->header.stamp};
 


### PR DESCRIPTION
This supports all 3 node composition methods:
1. manual composition (foo_main) from another package
2. CLI composition
3. Launch file composition

The show address stuff is the stuff I used for debugging, and isn't required.