### PR TITLE
No rosdep key for GTSAM, removing

### DIFF
--- a/fiducial_vlam/package.xml
+++ b/fiducial_vlam/package.xml
@@ -19,7 +19,6 @@
   <depend>cv_bridge</depend>
   <depend>fiducial_vlam_msgs</depend>
   <depend>geometry_msgs</depend>
-  <depend>GTSAM</depend>
   <depend>libopencv-dev</depend>
   <depend>rclcpp</depend>
   <depend>ros2_shared</depend>


### PR DESCRIPTION
GTSAM isn't a rosdep key (rosdep doesn't know how to install GTSAM), so it shouldn't be listed in the package.xml file.